### PR TITLE
Swift 3 / NSUserDefaults / Thin spacers

### DIFF
--- a/Blackspace.xcodeproj/project.pbxproj
+++ b/Blackspace.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 				TargetAttributes = {
 					CE4238631BCC37C100B1AFBD = {
 						CreatedOnToolsVersion = 7.0.1;
+						LastSwiftMigration = 0830;
 					};
 				};
 			};
@@ -238,6 +239,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.peterpistorius.Blackspace;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -250,6 +252,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.peterpistorius.Blackspace;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Blackspace/AppDelegate.swift
+++ b/Blackspace/AppDelegate.swift
@@ -13,11 +13,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
 
 
-    func applicationDidFinishLaunching(aNotification: NSNotification) {
+    func applicationDidFinishLaunching(_ aNotification: Notification) {
         // Insert code here to initialize your application
     }
 
-    func applicationWillTerminate(aNotification: NSNotification) {
+    func applicationWillTerminate(_ aNotification: Notification) {
         // Insert code here to tear down your application
     }
 

--- a/Blackspace/Base.lproj/Main.storyboard
+++ b/Blackspace/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="15A284" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
-        <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="8191"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12121"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Application-->
@@ -642,7 +642,7 @@
                         <outlet property="delegate" destination="Voe-Tx-rLC" id="PrD-fu-P6m"/>
                     </connections>
                 </application>
-                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Void" customModuleProvider="target"/>
+                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Blackspace" customModuleProvider="target"/>
                 <customObject id="Ady-hI-5gd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="75" y="0.0"/>
@@ -668,14 +668,14 @@
         <!--Void-->
         <scene sceneID="hIz-AP-VOD">
             <objects>
-                <viewController title="Void" id="XfG-lQ-9wD" customClass="ViewController" customModule="Void" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController title="Void" id="XfG-lQ-9wD" customClass="ViewController" customModule="Blackspace" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="m2S-Jp-Qdl">
                         <rect key="frame" x="0.0" y="0.0" width="281" height="205"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uvt-O7-Xt4">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uvt-O7-Xt4">
                                 <rect key="frame" x="18" y="75" width="245" height="110"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="DB7-F3-3HI">
                                     <font key="font" metaFont="system"/>
                                     <string key="title">I opened my eyes to only see the void.
@@ -689,18 +689,28 @@ Poetry.
                                 </textFieldCell>
                             </textField>
                             <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vxp-sw-Iya">
-                                <rect key="frame" x="72" y="22" width="137" height="32"/>
-                                <animations/>
-                                <buttonCell key="cell" type="push" title="Add blackspace" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="VM2-16-Lvb">
+                                <rect key="frame" x="14" y="22" width="109" height="32"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="push" title="Add spacer" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="VM2-16-Lvb">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
-                                    <action selector="didClickInsertVoid:" target="XfG-lQ-9wD" id="6X0-BC-ERD"/>
+                                    <action selector="didClickInsertSmallVoid:" target="rPt-NT-nkU" id="wgX-2M-ln9"/>
+                                </connections>
+                            </button>
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="szx-g5-fX5">
+                                <rect key="frame" x="124" y="22" width="143" height="32"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="push" title="Add large spacer" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="xIs-rX-xhg">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="didClickInsertVoid:" target="rPt-NT-nkU" id="Gye-T5-fB4"/>
                                 </connections>
                             </button>
                         </subviews>
-                        <animations/>
                     </view>
                 </viewController>
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>

--- a/Blackspace/Info.plist
+++ b/Blackspace/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>20151012</string>
+	<string>20170715</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Blackspace/ViewController.swift
+++ b/Blackspace/ViewController.swift
@@ -4,25 +4,48 @@
 //
 //  Created by Peter Pistorius on 12/10/15.
 //  Copyright © 2015 Peter Pistorius. All rights reserved.
-//  (I don't care.)
+//  Updated by Perceval Faramaz on 15/07/17.
+//  Portions copyright © 2017 Perceval Faramaz. All rights reserved.
+//  (Me neither.)
 //
 
 import Cocoa
 
 class ViewController: NSViewController {
-
-    func executeCommandLineTask(path: String, arguments: Array<String>) {
+    
+    func buildTileDictionary(_ small: Bool) -> Dictionary<String, String> {
+        var dict = Dictionary<String, String>()
+        dict["tile-type"] = (small) ? "small-spacer-tile" : "spacer-tile"
+        return dict
+    }
+    
+    func reloadDock() {
+        let runningApplications = NSWorkspace.shared().runningApplications
+        for app in runningApplications {
+            if app.bundleIdentifier == "com.apple.dock" {
+                kill( app.processIdentifier, SIGKILL );
+            }
+        }
+    }
+    
+    func insertSpacer(_ small: Bool) {
+        let dockDefaults = UserDefaults(suiteName: "com.apple.dock")
         
-        let task = NSTask()
-        task.launchPath = path
-        task.arguments = arguments
-        task.launch()
-        task.waitUntilExit()
+        guard var dockArray = dockDefaults?.array(forKey: "persistent-apps") else { return }
+        
+        dockArray.append( buildTileDictionary(small) )
+        
+        dockDefaults!.set(dockArray, forKey: "persistent-apps")
+        
+        reloadDock()
     }
 
-    @IBAction func didClickInsertVoid(sender: AnyObject) {
-        executeCommandLineTask("/usr/bin/defaults", arguments: ["write", "com.apple.dock", "persistent-apps", "-array-add", "{\"tile-type\"=\"spacer-tile\";}"]);
-        executeCommandLineTask("/usr/bin/killall", arguments: ["Dock"]);
+    @IBAction func didClickInsertVoid(_ sender: AnyObject) {
+        insertSpacer(false)
+    }
+    
+    @IBAction func didClickInsertSmallVoid(_ sender: AnyObject) {
+        insertSpacer(true)
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This is most commonly used as a way to seperate apps into logical categories.
 
 To remove a space drag it off the Dock, like you would any other icon.
 
-#### [Download](https://github.com/perfaram/Blackspace/releases/download/1.1/Blackspace.app.zip)
+#### [Download](https://github.com/perfaram/Blackspace/releases/download/1.1/Blackspace.zip)
 
-[Download Blackspace.app](https://github.com/perfaram/Blackspace/releases/download/1.1/Blackspace.app.zip)
+[Download Blackspace.app](https://github.com/perfaram/Blackspace/releases/download/1.1/Blackspace.zip)
 
 
 #### How does it work?

--- a/README.md
+++ b/README.md
@@ -1,25 +1,27 @@
 ### Blackspace
 
-Blackspace is an application that adds "blank" spaces to the OS X dock. 
+Blackspace is an application that adds "blank" spaces (or "spacers") to the macOS Dock.
 
-![](https://github.com/peterp/Blackspace/blob/master/dock_example.png)
+![](https://github.com/perfaram/Blackspace/blob/master/dock_example.png)
 
 This is most commonly used as a way to seperate apps into logical categories.
 
 To remove a space drag it off the Dock, like you would any other icon.
 
-#### [Download](https://github.com/peterp/Blackspace/releases/download/1.0/Blackspace.app.zip)
+#### [Download](https://github.com/perfaram/Blackspace/releases/download/1.1/Blackspace.app.zip)
 
-[Download Blackspace.app](https://github.com/peterp/Blackspace/releases/download/1.0/Blackspace.app.zip)
+[Download Blackspace.app](https://github.com/perfaram/Blackspace/releases/download/1.1/Blackspace.app.zip)
 
 
 #### How does it work?
 
-It uses the following commands to achieve this, so if you're comfortable with using the Terminal then just do the following instead:
+It uses a programmatic equivalent to the following commands to add Dock spacers, so if you're comfortable with using the Terminal then just do the following instead:
 
 ```
 > defaults write com.apple.dock persistent-apps -array-add '{"tile-type"="spacer-tile";}'
 > killall Dock
 ```
+
+Or, if you want a thin spacer, replaces `spacer-tile` by `small-spacer-tile`.
 
 Enjoy.


### PR DESCRIPTION
The biggest change I made is basically avoiding command-line-style calls (using `NSTask`), by switching to direct use of the NSUserDefaults API. Aside, I added the ability to create thin spacers (`small-space-tile` instead of `spacer-tile`), and I let Xcode convert to the new Swift 3 syntax.